### PR TITLE
run.sh: add --shm-size arg to prevent frequent tab crashes.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,7 @@
 set -eux
 docker run -ti --rm -e DISPLAY \
   --cap-add=NET_ADMIN --device /dev/net/tun \
+  --shm-size 256M \
   -v /tmp/.X11-unix:/tmp/.X11-unix \
   -v `pwd`/openvpn:/etc/openvpn \
   -v `pwd`/shared:/home/user/Downloads \


### PR DESCRIPTION
fix #1 
I don't know if 256M is too big. However, I have confirmed that 128M is
not enough( still crashes ).

reference: https://github.com/pytorch/pytorch/issues/2244